### PR TITLE
Add blog + refresh CV content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site/
 .sass-cache/
 .jekyll-metadata
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,16 @@
+source "https://rubygems.org"
+
+# Use the github-pages gem so local builds match GitHub Pages exactly.
+# This pins Jekyll and bundles the allowed plugins (including jekyll-feed).
+gem "github-pages", group: :jekyll_plugins
+
+# Faster watching on macOS
+gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Stdlib gems unbundled from Ruby 3.4+ that the pinned Jekyll (3.9.x) still requires.
+# Needed only for local builds on modern Ruby; harmless on GitHub Pages.
+gem "csv"
+gem "base64"
+gem "bigdecimal"
+gem "logger"
+gem "ostruct"

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,8 @@
 
-title: My Resume
-url: 'www.lalet.me'
+title: Lalet Scaria
+description: Staff Engineer (Platform/Reliability) — notes on cloud platforms, Kubernetes, and reliability.
+author: Lalet Scaria
+url: 'https://lalet.me'
 baseurl: '' #change it according to your repository name
 
 
@@ -14,13 +16,12 @@ baseurl: '' #change it according to your repository name
 
 #Profile information
 name: Lalet Scaria
-tagline: Master's Student
+tagline: Staff Engineer — Platform / Reliability
 pic: profile.png  #place a 100x100 picture inside /assets/images/ folder and provide the name of the file below
 
 #sidebar links
 email: laletscaria+site@gmail.com
-phone: 514-295-24(eight)(eight)
-website: 'www.lalet.me'  #do not add http://
+website: 'lalet.me'  #do not add http://
 linkedin: laletscaria
 github: lalet
 twitter: '@laletscaria'
@@ -28,4 +29,9 @@ twitter: '@laletscaria'
 
 # Tracker
 analytics: #UA-83979019-1
+
+# Plugins (GitHub Pages whitelisted)
+plugins:
+  - jekyll-feed
+
 #Update all the sections by editing the files inside _includes folder.

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -1,6 +1,6 @@
-<div class="remove-container container-block">
-<h2 class="container-block-title">About Theme</h2>
-<ul class="list-unstyled interests-list">
-<a target="_blank" href="https://www.youtube.com/watch?v=Jnmj1dXDbNk"><li>How to use?</li></a>
-</ul>
+<div class="about-container container-block">
+<h2 class="container-block-title">About</h2>
+<p>Platform &amp; reliability engineer who likes turning messy infrastructure into
+boring, dependable systems. I write up what I learn at
+<a href="{{ '/blog' | relative_url }}">my blog</a>.</p>
 </div><!--//About-->

--- a/_includes/career-profile.html
+++ b/_includes/career-profile.html
@@ -1,8 +1,10 @@
 <section class="section summary-section">
 <h2 class="section-title"><i class="fa fa-user"></i>Career Profile</h2>
 <div class="summary">
-    <p>Master's Student at Concordia University. Member of <a href="https://big-data-lab-team.github.io/">Big Data Infrastructures for Neuroinformatics Lab(/bin)</a> </br>
-       Working under <a href="https://users.encs.concordia.ca/~tglatard">Dr:Tristan Glatard</a> on <a href="https://github.com/big-data-lab-team/repro-tools">"Reproducibility of Human Connectome Project Preprocessing Pipelines across operating systems"</a> </br>
-     </p>
+    <p>Staff Engineer focused on cloud platform and reliability engineering. I design and run
+       large-scale infrastructure on Kubernetes with Terraform and GitOps, build vendor-agnostic
+       observability (OpenTelemetry), and make distributed systems — including blockchain and
+       stablecoin platforms — secure, scalable, and resilient.
+    </p>
 </div><!--//summary-->
 </section><!--//section-->

--- a/_includes/certifications.html
+++ b/_includes/certifications.html
@@ -1,0 +1,23 @@
+ <div class="education-container container-block">
+<h2 class="container-block-title">Certifications</h2>
+<div class="item">
+    <h4 class="degree">AWS Advanced Networking — Specialty</h4>
+    <h5 class="meta">A Cloud Guru</h5>
+    <div class="time">2023</div>
+</div><!--//item-->
+<div class="item">
+    <h4 class="degree">Google Cloud Platform Specialization</h4>
+    <h5 class="meta">Coursera</h5>
+    <div class="time">2018</div>
+</div><!--//item-->
+<div class="item">
+    <h4 class="degree">Deep Learning Specialization</h4>
+    <h5 class="meta">Coursera</h5>
+    <div class="time">2017</div>
+</div><!--//item-->
+<div class="item">
+    <h4 class="degree">Machine Learning Fundamentals</h4>
+    <h5 class="meta">Coursera &amp; Udacity</h5>
+    <div class="time">2017</div>
+</div><!--//item-->
+</div><!--//education-container-->

--- a/_includes/education.html
+++ b/_includes/education.html
@@ -1,6 +1,11 @@
  <div class="education-container container-block">
 <h2 class="container-block-title">Education</h2>
 <div class="item">
+    <h4 class="degree">Machine Learning</h4>
+    <h5 class="meta">University of Toronto (SCS)</h5>
+    <div class="time">2022</div>
+</div><!--//item-->
+<div class="item">
     <h4 class="degree">MASc in Software Engineering</h4>
     <h5 class="meta">Concordia University</h5>
     <div class="time">2016 - 2018</div>

--- a/_includes/experience.html
+++ b/_includes/experience.html
@@ -1,40 +1,81 @@
 <section class="section experiences-section">
                 <h2 class="section-title"><i class="fa fa-briefcase"></i>Experiences</h2>
-                
+
                 <div class="item">
                     <div class="meta">
                         <div class="upper-row">
-                            <h3 class="job-title">Intern Software Developer</h3>
-                            <div class="time">May 2017 - Present</div>
+                            <h3 class="job-title">Staff Engineer — Platform / Reliability</h3>
+                            <div class="time">Jan 2023 - Present</div>
                         </div><!--//upper-row-->
-                        <div class="company">MCIN, Montreal</div>
+                        <div class="company">Ripple — Toronto, Canada (Remote)</div>
                     </div><!--//meta-->
                     <div class="details">
-                        <p> Software developer to port research applications to CBRAIN</p> 
+                        <p>Designed and built the RLUSD stablecoin infrastructure on Amazon EKS using Terraform, ArgoCD (GitOps), and Istio, with passwordless IAM/Vault auth and Okta/Auth0 multi-tenancy (SAML/OIDC). Built a zero-code OpenTelemetry framework unifying logs, metrics, and traces across 100% of clusters. Architected database-coordinated idempotency (SQS/SNS, DLQ, optimistic locking) for exactly-once blockchain processing, and a Golang RPC proxy with circuit-breaker failover for zero-downtime connectivity. Cut infrastructure cost ~30% through IaC standardization and reusable Terraform modules.</p>
                     </div><!--//details-->
                 </div><!--//item-->
-		<div class="item">
+
+                <div class="item">
                     <div class="meta">
                         <div class="upper-row">
-                            <h3 class="job-title">Teaching Assistant(Comp. Networks)</h3>
-                            <div class="time">Jan 2017 - Apr 2017</div>
+                            <h3 class="job-title">Staff Engineer — Cloud Platform / Developer Excellence</h3>
+                            <div class="time">Nov 2020 - Dec 2022</div>
                         </div><!--//upper-row-->
-                        <div class="company">Concordia University, Montreal</div>
+                        <div class="company">Lookout — Toronto, Canada (Remote)</div>
                     </div><!--//meta-->
                     <div class="details">
-                        <p> Assisted students with assignments and projects regarding computer networks.</p>
+                        <p>Led design of a FedRAMP-compliant Google Cloud platform built with Terraform. Stood up a Jenkins-on-Kubernetes CI/CD platform with Helm, taking code from GitHub Enterprise commit to production via Jenkins, JFrog Artifactory, and Spinnaker. Integrated the ELK stack and Datadog custom-metrics auto-discovery for observability.</p>
                     </div><!--//details-->
                 </div><!--//item-->
-		<div class="item">
+
+                <div class="item">
                     <div class="meta">
                         <div class="upper-row">
-                            <h3 class="job-title">Intern Software Developer</h3>
-                            <div class="time">May 2016 - Oct 2016</div>
+                            <h3 class="job-title">Technology Associate</h3>
+                            <div class="time">Aug 2019 - Nov 2020</div>
                         </div><!--//upper-row-->
-                        <div class="company">Verge Comm., Montreal</div>
+                        <div class="company">Morgan Stanley — Montreal, Canada</div>
                     </div><!--//meta-->
                     <div class="details">
-                        <p> Software developer for news publishing platfrom. Ported database from mySQL to mongoDB.</p>
+                        <p>Led design and implementation of features to preprocess and analyze firm-wide data, generating metrics on DevOps and Agile practice adoption.</p>
+                    </div><!--//details-->
+                </div><!--//item-->
+
+                <div class="item">
+                    <div class="meta">
+                        <div class="upper-row">
+                            <h3 class="job-title">Solution Developer</h3>
+                            <div class="time">Feb 2019 - Aug 2019</div>
+                        </div><!--//upper-row-->
+                        <div class="company">Deloitte — Montreal, Canada</div>
+                    </div><!--//meta-->
+                    <div class="details">
+                        <p>Designed and built end-to-end data-processing applications using big-data technologies and cloud services, and analyzed processed data to derive actionable insights.</p>
+                    </div><!--//details-->
+                </div><!--//item-->
+
+                <div class="item">
+                    <div class="meta">
+                        <div class="upper-row">
+                            <h3 class="job-title">Software Developer (Intern — Data &amp; Pipelines)</h3>
+                            <div class="time">May 2017 - Sep 2018</div>
+                        </div><!--//upper-row-->
+                        <div class="company">McGill Center for Integrated Neuroscience — Montreal, Canada</div>
+                    </div><!--//meta-->
+                    <div class="details">
+                        <p>Delivered projects on containerization, deployment, and management of research applications, including EEG and neuroimaging workflows.</p>
+                    </div><!--//details-->
+                </div><!--//item-->
+
+                <div class="item">
+                    <div class="meta">
+                        <div class="upper-row">
+                            <h3 class="job-title">Software Developer</h3>
+                            <div class="time">Feb 2013 - Apr 2016</div>
+                        </div><!--//upper-row-->
+                        <div class="company">AC Nielsen (TCS Client) — Chennai, India</div>
+                    </div><!--//meta-->
+                    <div class="details">
+                        <p>Java developer for a data-warehouse backend (IBM Netezza) running daily batch ETL of customer-insights data.</p>
                     </div><!--//details-->
                 </div><!--//item-->
             </section><!--//section-->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,8 +4,9 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="A beautiful Jekyll theme for creating resume">
-    <link rel="shortcut icon" href="favicon.ico">  
+    <meta name="description" content="{% if site.description %}{{ site.description }}{% else %}A beautiful Jekyll theme for creating resume{% endif %}">
+    {% feed_meta %}
+    <link rel="shortcut icon" href="favicon.ico">
     <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,400italic,300italic,300,500italic,700,700italic,900,900italic' rel='stylesheet' type='text/css'>
     <!-- Global CSS -->
     <link rel="stylesheet" href="{{site.baseurl}}/assets/plugins/bootstrap/css/bootstrap.min.css">   

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -19,10 +19,8 @@
                     
                     {% if site.phone %}
                     <li class="phone"><i class="fa fa-phone"></i><a href="tel:{{site.phone}}">{{site.phone}}</a></li>
-                    {% else %}
-                    <li class="phone"><i class="fa fa-phone"></i><a href="tel:012 345 6789">012 345 6789</a></li>
                     {% endif %}
-                    
+
                     {% if site.website %}
                     <li class="website"><i class="fa fa-globe"></i><a href="http://{{site.website}}" target="_blank">{{site.website}}</a></li>
                     {% else %}
@@ -49,7 +47,17 @@
                     
                 </ul>
             </div><!--//contact-container-->
+
+            <div class="nav-container container-block">
+                <ul class="list-unstyled nav-list">
+                    <li><i class="fa fa-home"></i><a href="{{ '/' | relative_url }}">Home</a></li>
+                    <li><i class="fa fa-pencil"></i><a href="{{ '/blog' | relative_url }}">Blog</a></li>
+                    <li><i class="fa fa-rss"></i><a href="{{ '/feed.xml' | relative_url }}">RSS</a></li>
+                </ul>
+            </div><!--//nav-container-->
+
            {% include education.html %}
+           {% include certifications.html %}
            {% include language.html %}
            {% include interests.html %}
            {% include about.html %}

--- a/_includes/skills.html
+++ b/_includes/skills.html
@@ -1,53 +1,70 @@
 <section class="skills-section section">
                 <h2 class="section-title"><i class="fa fa-rocket"></i>Skills &amp; Proficiency</h2>
-                <div class="skillset">        
+                <div class="skillset">
+
+                    <div class="item">
+                        <h3 class="level-title">Kubernetes</h3>
+                        <div class="level-bar">
+                            <div class="level-bar-inner" data-level="90%">
+                            </div>
+                        </div><!--//level-bar-->
+                    </div><!--//item-->
+
+                    <div class="item">
+                        <h3 class="level-title">Terraform &amp; IaC</h3>
+                        <div class="level-bar">
+                            <div class="level-bar-inner" data-level="90%">
+                            </div>
+                        </div><!--//level-bar-->
+                    </div><!--//item-->
+
+                    <div class="item">
+                        <h3 class="level-title">AWS &amp; Google Cloud</h3>
+                        <div class="level-bar">
+                            <div class="level-bar-inner" data-level="85%">
+                            </div>
+                        </div><!--//level-bar-->
+                    </div><!--//item-->
+
+                    <div class="item">
+                        <h3 class="level-title">Observability (OpenTelemetry, ELK, Grafana)</h3>
+                        <div class="level-bar">
+                            <div class="level-bar-inner" data-level="85%">
+                            </div>
+                        </div><!--//level-bar-->
+                    </div><!--//item-->
+
+                    <div class="item">
+                        <h3 class="level-title">CI/CD (ArgoCD, Jenkins, Spinnaker)</h3>
+                        <div class="level-bar">
+                            <div class="level-bar-inner" data-level="85%">
+                            </div>
+                        </div><!--//level-bar-->
+                    </div><!--//item-->
+
+                    <div class="item">
+                        <h3 class="level-title">Golang</h3>
+                        <div class="level-bar">
+                            <div class="level-bar-inner" data-level="80%">
+                            </div>
+                        </div><!--//level-bar-->
+                    </div><!--//item-->
+
                     <div class="item">
                         <h3 class="level-title">Python</h3>
                         <div class="level-bar">
-                            <div class="level-bar-inner" data-level="90%">
-                            </div>                                      
-                        </div><!--//level-bar-->                                 
+                            <div class="level-bar-inner" data-level="85%">
+                            </div>
+                        </div><!--//level-bar-->
                     </div><!--//item-->
-                    
-                    <div class="item">
-                        <h3 class="level-title">Javascript &amp; jQuery</h3>
-                        <div class="level-bar">
-                            <div class="level-bar-inner" data-level="60%">
-                            </div>                                      
-                        </div><!--//level-bar-->                                 
-                    </div><!--//item-->
-                    
-                    <div class="item">
-                        <h3 class="level-title">Docker &amp; Singularity</h3>
-                        <div class="level-bar">
-                            <div class="level-bar-inner" data-level="90%">
-                            </div>                                      
-                        </div><!--//level-bar-->                                 
-                    </div><!--//item-->
-                    
-                    <div class="item">
-                        <h3 class="level-title">Machine Learning &amp; Data Science</h3>
-                        <div class="level-bar">
-                            <div class="level-bar-inner" data-level="60%">
-                            </div>                                      
-                        </div><!--//level-bar-->                                 
-                    </div><!--//item-->
-                    
+
                     <div class="item">
                         <h3 class="level-title">Java</h3>
                         <div class="level-bar">
-                            <div class="level-bar-inner" data-level="85%">
-                            </div>                                      
-                        </div><!--//level-bar-->                                 
+                            <div class="level-bar-inner" data-level="80%">
+                            </div>
+                        </div><!--//level-bar-->
                     </div><!--//item-->
-                    
-                    <div class="item">
-                        <h3 class="level-title">Big Data(Hadoop, Spark)</h3>
-                        <div class="level-bar">
-                            <div class="level-bar-inner" data-level="75%">
-                            </div>                                      
-                        </div><!--//level-bar-->                                 
-                    </div><!--//item-->
-                    
-                </div>  
+
+                </div>
             </section><!--//skills-section-->

--- a/_includes/talks.html
+++ b/_includes/talks.html
@@ -1,0 +1,12 @@
+<section class="section talks-section">
+                <h2 class="section-title"><i class="fa fa-microphone"></i>Research &amp; Talks</h2>
+                <div class="item">
+                    <span class="project-title">Investigator Presentation — INCF 2017</span> - <span class="project-tagline">Presented my thesis, "A framework for evaluating the reproducibility of neuroimaging pipelines across operating systems," at the INCF Conference, Kuala Lumpur, Malaysia.</span>
+                </div><!--//item-->
+                <div class="item">
+                    <span class="project-title">Brain Imaging Data Structure Hackathon — Stanford University (2017)</span> - <span class="project-tagline">Built a pipeline using the Apache Spark engine to speed up neuroimaging pipelines.</span>
+                </div><!--//item-->
+                <div class="item">
+                    <span class="project-title">NeuroHackWeek — University of Washington (2017)</span> - <span class="project-tagline">Selected as one of 60 participants; applied machine learning and data-visualization techniques used in the neuroimaging community.</span>
+                </div><!--//item-->
+            </section><!--//section-->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,20 @@
+---
+layout: default
+---
+<section class="section blog-post-section">
+    <a class="back-to-blog" href="{{ '/blog' | relative_url }}">&larr; Back to blog</a>
+    <h2 class="section-title"><i class="fa fa-pencil"></i>{{ page.title }}</h2>
+    <div class="meta">
+        <div class="time">{{ page.date | date: "%B %-d, %Y" }}</div>
+    </div><!--//meta-->
+    {% if page.tags.size > 0 %}
+    <div class="post-tags">
+        {% for tag in page.tags %}
+        <a class="post-tag" href="{{ '/tags' | relative_url }}#{{ tag | slugify }}">#{{ tag }}</a>
+        {% endfor %}
+    </div><!--//post-tags-->
+    {% endif %}
+    <div class="post-content">
+        {{ content }}
+    </div><!--//post-content-->
+</section><!--//section-->

--- a/_posts/2026-06-21-welcome-to-my-blog.md
+++ b/_posts/2026-06-21-welcome-to-my-blog.md
@@ -1,0 +1,37 @@
+---
+layout: post
+title: "Welcome to my blog"
+date: 2026-06-21
+tags: [meta, learning]
+---
+
+This is the first post on my blog, where I'll write up things I learn while
+building and running platform infrastructure — Kubernetes, Terraform, GitOps,
+observability, and the occasional rabbit hole.
+
+## Why a blog?
+
+Writing things down forces me to actually understand them. The goal is short,
+practical notes I'd want to find again later.
+
+## How posts work
+
+Each post is a Markdown file in `_posts/` named `YYYY-MM-DD-title.md` with a bit
+of front matter at the top:
+
+```yaml
+---
+layout: post
+title: "Your title"
+date: 2026-06-21
+tags: [kubernetes, terraform]
+---
+```
+
+Then just write Markdown. Code blocks, lists, and links all work:
+
+- Fenced code blocks get syntax highlighting
+- `inline code` is supported
+- [Links](https://lalet.me) work as expected
+
+That's it — commit, push, and it goes live.

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,36 @@
+---
+layout: default
+title: Blog
+permalink: /blog/
+---
+<section class="section blog-section">
+    <h2 class="section-title"><i class="fa fa-pencil"></i>Blog</h2>
+    <div class="intro">
+        <p>Notes and learnings on platform engineering, reliability, and whatever else I'm digging into.</p>
+    </div><!--//intro-->
+
+    {% if site.posts.size > 0 %}
+        {% for post in site.posts %}
+        <div class="item">
+            <div class="meta">
+                <div class="upper-row">
+                    <h3 class="job-title"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
+                    <div class="time">{{ post.date | date: "%B %-d, %Y" }}</div>
+                </div><!--//upper-row-->
+            </div><!--//meta-->
+            <div class="details">
+                <p>{{ post.excerpt | strip_html | truncatewords: 40 }}</p>
+                {% if post.tags.size > 0 %}
+                <div class="post-tags">
+                    {% for tag in post.tags %}
+                    <a class="post-tag" href="{{ '/tags' | relative_url }}#{{ tag | slugify }}">#{{ tag }}</a>
+                    {% endfor %}
+                </div><!--//post-tags-->
+                {% endif %}
+            </div><!--//details-->
+        </div><!--//item-->
+        {% endfor %}
+    {% else %}
+        <div class="intro"><p>No posts yet — check back soon.</p></div>
+    {% endif %}
+</section><!--//section-->

--- a/index.html
+++ b/index.html
@@ -8,7 +8,9 @@ layout: default
 {% include experience.html %}
             
 {% include projects.html %}
-            
+
+{% include talks.html %}
+
 {% include skills.html %}
 
 

--- a/tags.html
+++ b/tags.html
@@ -1,0 +1,33 @@
+---
+layout: default
+title: Tags
+permalink: /tags/
+---
+<section class="section tags-section">
+    <h2 class="section-title"><i class="fa fa-tags"></i>Tags</h2>
+
+    {% if site.tags.size > 0 %}
+    <div class="intro">
+        <p>
+        {% for tag in site.tags %}
+            <a class="post-tag" href="#{{ tag[0] | slugify }}">#{{ tag[0] }} ({{ tag[1].size }})</a>
+        {% endfor %}
+        </p>
+    </div><!--//intro-->
+
+    {% for tag in site.tags %}
+    <div class="item">
+        <h3 class="job-title" id="{{ tag[0] | slugify }}">#{{ tag[0] }}</h3>
+        <div class="details">
+            <ul class="list-unstyled">
+            {% for post in tag[1] %}
+                <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a> <span class="time">{{ post.date | date: "%b %-d, %Y" }}</span></li>
+            {% endfor %}
+            </ul>
+        </div><!--//details-->
+    </div><!--//item-->
+    {% endfor %}
+    {% else %}
+    <div class="intro"><p>No tags yet.</p></div>
+    {% endif %}
+</section><!--//section-->


### PR DESCRIPTION
## What
Adds a **blog** to the site and **refreshes the CV** content. Targets `gh-pages` (the GitHub Pages publish source for `lalet.me`).

### Blog (Jekyll-native, GitHub Pages-safe)
- `_layouts/post.html`, `blog.html` (`/blog`), `tags.html` (`/tags`, pure Liquid — no plugin)
- `jekyll-feed` RSS at `/feed.xml`; `{% feed_meta %}` in `head.html`
- **Home / Blog / RSS** nav added to the sidebar
- Sample post in `_posts/`; `Gemfile` (github-pages) for local builds

### CV refresh (from current résumé)
- Tagline → **Staff Engineer (Platform/Reliability)**; website → `lalet.me`; **phone removed**
- Career profile rewritten; full **experience** timeline (Ripple, Lookout, Morgan Stanley, Deloitte, McGill, AC Nielsen)
- Current **skills**; added U of T to **education** + new **Certifications** block; **Research & Talks** section
- Replaced the "About Theme" block with a personal blurb

## Deploy notes
- Keeps `baseurl: ''` and the `CNAME` (`lalet.me`) — **no Cloudflare/DNS change needed**.
- `url` set to `https://lalet.me` so RSS links are absolute/correct.
- Verified with a local Jekyll build using `baseurl: ''`: assets and links resolve at the apex root, post renders, `/tags` groups by tag, and `feed.xml` is valid.
- Writing posts later: drop `_posts/YYYY-MM-DD-title.md`, commit, push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)