### PR TITLE
Homelab Part 3 + Part 1 RPi update (high-level, humanized)

### DIFF
--- a/_posts/2026-06-21-homelab-part-1-hardware.md
+++ b/_posts/2026-06-21-homelab-part-1-hardware.md
@@ -54,9 +54,13 @@ clustering — the whole point of the exercise.
 
 ### 2× Raspberry Pi 5 — where it all started
 
-The Pis are still around. They were the original homelab and my first set of
-experiments, and they've earned a permanent spot. These days they handle the
-lighter, always-on bits while the OptiPlex nodes do the heavy lifting.
+The Pis are still around — they were the original homelab and my first set of
+experiments, and they've earned a permanent spot. But they're no longer just
+tinkering boxes: both now run **Talos Linux** as full members of the Kubernetes
+cluster (much more on that in Part 3). One serves as a **third control-plane
+node** — the tie-breaker that gives etcd a proper odd-numbered quorum — and the
+other runs as an **arm64 worker**. A Pi makes a great control-plane tie-breaker:
+it sips power and, unlike a laptop, powers itself back on after an outage.
 
 ### Storage: Buffalo TeraStation 5200 NVR
 

--- a/_posts/2026-06-21-homelab-part-1-hardware.md
+++ b/_posts/2026-06-21-homelab-part-1-hardware.md
@@ -5,134 +5,106 @@ date: 2026-06-21
 tags: [homelab, infrastructure, proxmox, kubernetes]
 ---
 
-This is the first post in a series on building out my homelab — a place to run
-the same platform infrastructure I work on professionally (Kubernetes, GitOps,
-observability) without a cloud bill attached to every experiment. Part 1 is the
-foundation: the physical hardware and how it's wired together.
+First post in a series on building out my homelab. The goal is to run the same
+kind of infrastructure I work on (Kubernetes, GitOps, observability) without
+paying a cloud bill for every experiment. Part 1 is the hardware.
 
-## How it started — and why it grew
+## How it started
 
-I'd been running a homelab on a couple of Raspberry Pis for a while. They were
-the perfect place to poke at things — small, cheap, low-power, and forgiving
-when I broke them.
+I ran a homelab on a couple of Raspberry Pis for a while. They were great for
+poking at things: small, cheap, low power, and hard to break in any permanent
+way.
 
-Then AI agents took off, and I wanted to experiment with running models locally
-with **Ollama**. That's where the Pis hit a wall: great for tinkering, not so
-great for anything compute- or memory-hungry. I wanted a real, multi-node
-environment I could run a proper Kubernetes cluster on — and host local LLMs
+Then I wanted to run models locally with Ollama, and the Pis ran out of room
+fast. Fine for tinkering, not for anything memory hungry. I wanted a real
+multi-node setup I could run a proper Kubernetes cluster on, and host local LLMs
 without paying per token.
 
-So I went shopping. The whole rule was **cheap**: everything here came off the
-secondhand marketplace, which is exactly why mini-PCs and a few small boxes beat
-a loud, power-hungry rack server.
+So I went shopping, secondhand and cheap. That budget is the whole reason this is
+mini PCs and a few small boxes instead of a loud rack server.
 
 ## The hardware
 
-Four small machines, a switch, and a NAS — nothing rack-mounted.
+Four small machines, a switch, and a NAS. Nothing rack mounted.
 
-### Compute: 2× Dell OptiPlex 3070 Micro
+### Compute: 2x Dell OptiPlex 3070 Micro
 
-The two workhorses, which I named **`plex1`** and **`plex2`**. They're identical,
-so here's the spec for one node (both are the same):
+The two workhorses, plex1 and plex2. They're identical:
 
 | Component | Spec (per node) |
-|-----------|-----------------|
-| CPU | Intel Core i5-8500T — 6 cores / 6 threads, 35 W |
-| RAM | 24 GB DDR4 |
+|---|---|
+| CPU | Intel Core i5-8500T (6 cores, 35 W) |
+| RAM | 24 GB |
 | Boot disk | ~256 GB NVMe |
-| Data disk | 2 TB SATA SSD |
-| Hypervisor | Proxmox VE 9.2.3 |
+| Data disk | 2 TB SSD |
+| Hypervisor | Proxmox VE 9 |
 
-The 3070 Micro hits the homelab sweet spot: a 35 W "T" CPU sips power and runs
-silent, but six cores and 24 GB of RAM are plenty to host a multi-node cluster —
-and finally enough headroom to run Ollama. The 2 TB SSD in each node holds the
-VM disks (`local-ssd`); the smaller NVMe handles boot and Proxmox itself.
+A 35 W CPU sips power and stays quiet, but six cores and 24 GB are plenty for a
+few VMs, with enough headroom left for Ollama. I picked two boxes instead of one
+bigger one on purpose, so I could split the cluster across machines and actually
+learn how multi-node setups behave.
 
-Two nodes instead of one bigger box was deliberate: it lets me split the
-Kubernetes control plane across physical hosts and actually learn multi-node
-clustering — the whole point of the exercise.
+### 2x Raspberry Pi 5
 
-### 2× Raspberry Pi 5 — where it all started
-
-The Pis are still around — they were the original homelab and my first set of
-experiments, and they've earned a permanent spot. But they're no longer just
-tinkering boxes: both now run **Talos Linux** as full members of the Kubernetes
-cluster (much more on that in Part 3). One serves as a **third control-plane
-node** — the tie-breaker that gives etcd a proper odd-numbered quorum — and the
-other runs as an **arm64 worker**. A Pi makes a great control-plane tie-breaker:
-it sips power and, unlike a laptop, powers itself back on after an outage.
+The Pis are still here, and they're not just tinkering boxes anymore. Both run
+Talos Linux as full members of the Kubernetes cluster (Part 3 covers that). One
+is a third control-plane node, the tie-breaker that gives etcd an odd-numbered
+quorum. The other is an arm64 worker. A Pi makes a good tie-breaker: low power,
+and unlike a laptop it comes back on by itself after an outage.
 
 ### Storage: Buffalo TeraStation 5200 NVR
 
-Bulk storage and backups live on a secondhand **Buffalo TeraStation 5200 NVR** —
-a 2-bay business NAS, loaded with **2× 4 TB** drives. It has dual Gigabit ports,
-so the box itself isn't the bottleneck; in practice it runs well behind the
-node-local SSDs, which is exactly why it stays in the "cold storage / backups"
-tier and each compute node keeps its own local 2 TB SSD for anything live or
-performance-sensitive.
+Bulk storage and backups live on a secondhand Buffalo TeraStation, a 2-bay box
+with two 4 TB drives. It has gigabit networking, so the box itself isn't the
+limit, but it's slower than the local SSDs, so it stays in the backups tier.
+Anything that needs to be quick lives on the node-local SSDs instead.
 
 ### Networking: TP-Link switch
 
-Everything sits on a single flat LAN:
+Everything sits on one flat LAN:
 
 ```
                 Internet
-                   │
-          ┌────────┴─────────┐
-          │   home router     │  gateway, DHCP
-          └────────┬─────────┘
-                   │
-          ┌────────┴─────────┐
-          │  TP-Link switch   │  unmanaged, 5 V powered
-          └────────┬─────────┘
-         ┌─────┬────┴───┬──────┬───────┐
-       plex1  plex2   Buffalo  rpi5    rpi5
+                   |
+            home router   (gateway, DHCP)
+                   |
+            TP-Link switch  (unmanaged, 5 V)
+        |       |        |        |       |
+      plex1   plex2   Buffalo    rpi5    rpi5
                        NAS
 ```
 
-The switch is a plain, unmanaged 5 V-powered TP-Link unit — the same low-power
-class of gear as the Pis themselves. No VLANs, no management, nothing fancy: the
-OptiPlex Micros each have a single onboard 1 GbE NIC, and the switch just ties
-the nodes, NAS, and Pis together off the home router. (Segmenting this into
-VLANs is on the list for a later post.)
+It's a plain unmanaged 5 V TP-Link unit, the same low-power class as the Pis. No
+VLANs, nothing fancy. The OptiPlex boxes each have one gigabit NIC, and the
+switch just ties everything together off the router. VLANs are on the list for a
+later post.
 
-### Power & physical setup
+### Power
 
-It's all low-power by design — those 35 W CPUs idle quietly. **No UPS yet**;
-that's the next purchase, because the one thing this setup can't currently
-survive gracefully is a power blip.
+Low power by design, since those 35 W CPUs idle quietly. No UPS yet. That's the
+next buy, because a power blip is the one thing this setup can't ride out right
+now.
 
-## What's actually running on it
+## What's running on it
 
-To make the hardware concrete — here's the current Kubernetes cluster, running
-as Proxmox VMs spread across the two nodes:
+The Kubernetes cluster runs as VMs on the two Proxmox nodes, plus the two Pis.
+The Proxmox side:
 
-| VM | Role | Host | vCPU | RAM |
-|----|------|------|------|-----|
-| `cp1` | control plane | `plex1` | 4 | 4 GB |
-| `cp2` | control plane | `plex2` | 4 | 4 GB |
-| `worker1` | worker | `plex1` | 6 | 16 GB |
-| `worker2` | worker | `plex2` | 6 | 12 GB |
-| `worker3` | worker | `plex2` | 6 | 6 GB |
+| VM | Role | Host |
+|---|---|---|
+| cp1 | control plane | plex1 |
+| cp2 | control plane | plex2 |
+| worker1 | worker | plex1 |
+| worker2 | worker | plex2 |
+| worker3 | worker | plex2 |
 
-Two control-plane nodes and three workers, with the control plane split across
-physical hosts so a single node reboot doesn't take the cluster down. On top of
-this runs my GitOps/observability stack and the local-AI experiments that
-started this whole upgrade — the subject of later parts.
-
-## Decisions and trade-offs
-
-- **Secondhand mini-PCs over a rack server** — quiet, low-power, fits anywhere,
-  and *cheap*. The cost is no IPMI/iLO and limited expansion, which I can live with.
-- **Two nodes over one** — redundancy and a real multi-node cluster to learn on,
-  rather than one big single point of failure.
-- **Node-local SSD + a NAS for cold storage** — fast, node-local storage for
-  anything live; the Buffalo NAS strictly for backups and bulk.
+The two Pis add a third control plane and a fourth worker, so the full cluster is
+three control planes and four workers. On top of it runs my GitOps stack and the
+local-AI experiments that kicked off the whole upgrade.
 
 ## What's next
 
-With the metal racked (well, *shelved*) and on the network, **Part 2** covers the
-virtualization layer: installing Proxmox, the `plex1`/`plex2` setup, and how the
-Kubernetes VMs are laid out across them.
+Part 2 covers Proxmox: installing it on the two OptiPlex boxes and getting them
+ready to run the cluster.
 
-It's all learning — and the whole world's our stage, folks.
+It's all learning, and the whole world's our stage.

--- a/_posts/2026-06-22-homelab-part-3-kubernetes.md
+++ b/_posts/2026-06-22-homelab-part-3-kubernetes.md
@@ -1,109 +1,73 @@
 ---
 layout: post
-title: "Homelab, Part 3: A Talos Kubernetes Cluster on Proxmox and Raspberry Pis"
+title: "Homelab, Part 3: A Kubernetes Cluster on Talos"
 date: 2026-06-22 10:00:00
 tags: [homelab, kubernetes, talos, cilium, gitops]
 ---
 
 [Part 1]({{ '/2026/06/21/homelab-part-1-hardware.html' | relative_url }}) covered
-the hardware; [Part 2]({{ '/2026/06/22/homelab-part-2-proxmox.html' | relative_url }})
-got Proxmox running on the two OptiPlex Micros. This post is the payoff: a real
-**Kubernetes cluster** stretched across those Proxmox VMs *and* the Raspberry
-Pis from Part 1 — running **Talos Linux v1.13.4** and **Kubernetes v1.32.0**.
+the hardware and [Part 2]({{ '/2026/06/22/homelab-part-2-proxmox.html' | relative_url }})
+got Proxmox running. This is where it comes together: a Kubernetes cluster spread
+across the Proxmox VMs and the Raspberry Pis, running Talos Linux.
 
-## Why Talos instead of "just install Kubernetes"
+## Why Talos
 
-I didn't want to `apt install` a control plane and hand-maintain it. Talos Linux
-is a purpose-built Kubernetes OS: **immutable, API-driven, and with no SSH and no
-shell**. You don't log into a Talos node — you declare its config and apply it
-over an API. That's a mindset shift, but it's exactly the production-style,
-reproducible setup I wanted to practice: the whole cluster is described in
-files, generated with **talhelper**, and the VMs themselves are created on
-Proxmox with **OpenTofu**. Rebuilding a node is boring and repeatable instead of
-a snowflake.
+I didn't want to hand-maintain a control plane. Talos is a Linux built only for
+Kubernetes, with no SSH and no shell to log into. You don't manage a node by
+poking at it, you declare its config and apply it over an API. That sounds
+restrictive, and that's the point: the whole cluster lives in config files, so
+rebuilding a node is boring and repeatable instead of a one-off.
 
-## The shape of the cluster
+## The cluster
 
-Seven nodes, deliberately mixed:
+Seven nodes, mixed on purpose:
 
 | Role | Nodes | Where |
-|------|-------|-------|
-| control plane | `cp1`, `cp2` | Proxmox VMs (amd64) |
-| control plane | `cp3` | Raspberry Pi 5 (arm64) |
-| worker | `worker1`, `worker2`, `worker3` | Proxmox VMs (amd64) |
-| worker | `worker4` | Raspberry Pi 5 (arm64) |
+|---|---|---|
+| control plane | cp1, cp2 | Proxmox VMs (amd64) |
+| control plane | cp3 | Raspberry Pi (arm64) |
+| worker | worker1, worker2, worker3 | Proxmox VMs (amd64) |
+| worker | worker4 | Raspberry Pi (arm64) |
 
-A few deliberate choices in there:
+Three control planes, not two. Part 2 ended on the two-node quorum problem, and
+this is the fix: etcd wants an odd number, so a third control plane (a Pi) lets
+the cluster survive losing any one of them. The control planes sit on different
+machines, and a floating virtual IP is the API endpoint, so kubectl talks to the
+cluster rather than to one node. The amd64 VMs and the arm64 Pis run side by
+side, which keeps me honest about multi-arch images.
 
-- **Three control planes, not two.** Part 2 ended on the two-node quorum
-  problem; the cluster answers it here. etcd wants an odd number for quorum, so
-  the third control plane — a Raspberry Pi 5 — means the cluster survives losing
-  any one control-plane node. A Pi makes a perfect tie-breaker: low power, and
-  unlike a laptop it powers itself back on after an outage.
-- **The control plane is spread across physical hosts**, so a single Proxmox box
-  rebooting never takes the API down.
-- **A floating virtual IP** (managed by Talos) is the cluster's API endpoint, so
-  `kubectl` talks to "the cluster," not to one specific node.
-- **Mixed architecture.** The amd64 VMs and arm64 Pis run side by side in one
-  cluster — which keeps you honest about multi-arch container images.
+## The troubles
 
-## The troubles (this is a homelab, after all)
+A few things cost me real time.
 
-**Cilium + VXLAN silently ate cross-host traffic.** The cluster uses
-[Cilium](https://cilium.io) as the CNI (with Hubble for flow visibility). With
-the default VXLAN overlay, pods on the *same* node could talk, but pod-to-pod
-traffic *across* nodes just… vanished — no error, just dropped packets. On
-Proxmox the fix was switching Cilium to **native routing** instead of VXLAN.
-Easily a lost evening if you don't suspect the overlay.
+Cilium dropped traffic between nodes. With the default overlay, pods on the same
+node could talk but pods on different nodes couldn't, and it failed silently. On
+Proxmox the fix was switching Cilium to native routing.
 
-**The network interface name matters.** Talos pins addresses to a named NIC, and
-the name isn't the same everywhere: Proxmox virtio NICs come up as `ens18`, while
-the Raspberry Pi's onboard NIC is `end0`. Point the config at the wrong one and
-the static IP (and the control-plane VIP) simply never come up.
+The interface name matters. Talos pins an address to a named NIC, and the name
+isn't the same on the VMs as it is on the Pi. Point the config at the wrong one
+and the address just never comes up.
 
-**A bootstrap chicken-and-egg.** Cilium needs to reach the Kubernetes API to
-start — but if you point it at the floating VIP, the VIP doesn't exist yet
-because the control plane isn't up. The trick is to point Cilium at a *real*
-control-plane node IP to bootstrap, then switch it to the VIP once the cluster is
-healthy.
-
-**Getting Talos onto a Raspberry Pi is its own little dance.** The Pis don't run
-the stock Talos image — you build one with the `rpi_5` overlay (an Image Factory
-schematic), flash it to the boot media, and the Pi comes up in Talos
-**maintenance mode**, grabs a DHCP lease, and waits. From there you apply the
-generated machine config and it joins. Worth knowing the Pi's onboard NIC is
-`end0`, not `ens18` — same interface-name trap as above.
-
-**You can't taint a Talos worker from its own config.** I wanted the Pi worker
-(`worker4`) carrying a `NoSchedule` taint so heavy workloads stay on the beefier
-amd64 nodes. Setting that via Talos `machine.nodeTaints` *fails* on workers —
-kubelet's NodeRestriction admission won't let a node set its own taints, and the
-failure also blocks the node labels declared alongside it. The fix is to apply
-the taint out-of-band with `kubectl taint` after the node joins.
+There's also a bootstrap catch-22: Cilium needs the API to start, but the API's
+floating IP doesn't exist until the control plane is already up. You point Cilium
+at a real node to bootstrap, then move it to the floating IP once things settle.
 
 ## Storage
 
-Two storage classes, matching the hardware from Part 1:
+Two storage classes. NFS to the Buffalo NAS for bulk and shared data, and
+local-path on the SSDs for anything that needs to be quick.
 
-- **`nfs`** (the default) — backed by the Buffalo NAS over NFS, for bulk and
-  shared data.
-- **`local-path`** — fast, node-local storage on the 2 TB SSDs in the Proxmox
-  workers, for anything latency-sensitive.
+## What runs on it
 
-## What runs on top
-
-Everything is **GitOps**, managed by **ArgoCD** from a Git repo — Cilium,
-cert-manager, the storage drivers, and ArgoCD itself all reconcile from version
-control, so the cluster's desired state is the repo. On the workload side this is
-where the original goal from Part 1 finally lands: **Ollama** for local LLMs, and
-Plex with iGPU passthrough to one of the Proxmox workers.
+Everything is GitOps through ArgoCD, so the cluster's state is just a Git repo.
+On top of that sits the reason for the whole upgrade: Ollama for local LLMs, and
+Plex with the iGPU passed through for transcoding.
 
 ## What's next
 
-The cluster is up and self-managing. **Part 4** will go into the GitOps setup
-proper — how ArgoCD bootstraps everything, secrets handling, and exposing
-services with single sign-on.
+The cluster is up and mostly runs itself. Part 4 gets into the GitOps setup: how
+ArgoCD bootstraps everything, how secrets are handled, and how I reach services
+with single sign-on.
 
-Seven nodes, two architectures, one `kubectl` away — and finally a place to run
-local AI that isn't someone else's cloud. It's all learning, and the stage just
-got bigger.
+Seven nodes, two architectures, one kubectl away. It's all learning, and the
+stage just got bigger.

--- a/_posts/2026-06-22-homelab-part-3-kubernetes.md
+++ b/_posts/2026-06-22-homelab-part-3-kubernetes.md
@@ -1,0 +1,109 @@
+---
+layout: post
+title: "Homelab, Part 3: A Talos Kubernetes Cluster on Proxmox and Raspberry Pis"
+date: 2026-06-22 10:00:00
+tags: [homelab, kubernetes, talos, cilium, gitops]
+---
+
+[Part 1]({{ '/2026/06/21/homelab-part-1-hardware.html' | relative_url }}) covered
+the hardware; [Part 2]({{ '/2026/06/22/homelab-part-2-proxmox.html' | relative_url }})
+got Proxmox running on the two OptiPlex Micros. This post is the payoff: a real
+**Kubernetes cluster** stretched across those Proxmox VMs *and* the Raspberry
+Pis from Part 1 — running **Talos Linux v1.13.4** and **Kubernetes v1.32.0**.
+
+## Why Talos instead of "just install Kubernetes"
+
+I didn't want to `apt install` a control plane and hand-maintain it. Talos Linux
+is a purpose-built Kubernetes OS: **immutable, API-driven, and with no SSH and no
+shell**. You don't log into a Talos node — you declare its config and apply it
+over an API. That's a mindset shift, but it's exactly the production-style,
+reproducible setup I wanted to practice: the whole cluster is described in
+files, generated with **talhelper**, and the VMs themselves are created on
+Proxmox with **OpenTofu**. Rebuilding a node is boring and repeatable instead of
+a snowflake.
+
+## The shape of the cluster
+
+Seven nodes, deliberately mixed:
+
+| Role | Nodes | Where |
+|------|-------|-------|
+| control plane | `cp1`, `cp2` | Proxmox VMs (amd64) |
+| control plane | `cp3` | Raspberry Pi 5 (arm64) |
+| worker | `worker1`, `worker2`, `worker3` | Proxmox VMs (amd64) |
+| worker | `worker4` | Raspberry Pi 5 (arm64) |
+
+A few deliberate choices in there:
+
+- **Three control planes, not two.** Part 2 ended on the two-node quorum
+  problem; the cluster answers it here. etcd wants an odd number for quorum, so
+  the third control plane — a Raspberry Pi 5 — means the cluster survives losing
+  any one control-plane node. A Pi makes a perfect tie-breaker: low power, and
+  unlike a laptop it powers itself back on after an outage.
+- **The control plane is spread across physical hosts**, so a single Proxmox box
+  rebooting never takes the API down.
+- **A floating virtual IP** (managed by Talos) is the cluster's API endpoint, so
+  `kubectl` talks to "the cluster," not to one specific node.
+- **Mixed architecture.** The amd64 VMs and arm64 Pis run side by side in one
+  cluster — which keeps you honest about multi-arch container images.
+
+## The troubles (this is a homelab, after all)
+
+**Cilium + VXLAN silently ate cross-host traffic.** The cluster uses
+[Cilium](https://cilium.io) as the CNI (with Hubble for flow visibility). With
+the default VXLAN overlay, pods on the *same* node could talk, but pod-to-pod
+traffic *across* nodes just… vanished — no error, just dropped packets. On
+Proxmox the fix was switching Cilium to **native routing** instead of VXLAN.
+Easily a lost evening if you don't suspect the overlay.
+
+**The network interface name matters.** Talos pins addresses to a named NIC, and
+the name isn't the same everywhere: Proxmox virtio NICs come up as `ens18`, while
+the Raspberry Pi's onboard NIC is `end0`. Point the config at the wrong one and
+the static IP (and the control-plane VIP) simply never come up.
+
+**A bootstrap chicken-and-egg.** Cilium needs to reach the Kubernetes API to
+start — but if you point it at the floating VIP, the VIP doesn't exist yet
+because the control plane isn't up. The trick is to point Cilium at a *real*
+control-plane node IP to bootstrap, then switch it to the VIP once the cluster is
+healthy.
+
+**Getting Talos onto a Raspberry Pi is its own little dance.** The Pis don't run
+the stock Talos image — you build one with the `rpi_5` overlay (an Image Factory
+schematic), flash it to the boot media, and the Pi comes up in Talos
+**maintenance mode**, grabs a DHCP lease, and waits. From there you apply the
+generated machine config and it joins. Worth knowing the Pi's onboard NIC is
+`end0`, not `ens18` — same interface-name trap as above.
+
+**You can't taint a Talos worker from its own config.** I wanted the Pi worker
+(`worker4`) carrying a `NoSchedule` taint so heavy workloads stay on the beefier
+amd64 nodes. Setting that via Talos `machine.nodeTaints` *fails* on workers —
+kubelet's NodeRestriction admission won't let a node set its own taints, and the
+failure also blocks the node labels declared alongside it. The fix is to apply
+the taint out-of-band with `kubectl taint` after the node joins.
+
+## Storage
+
+Two storage classes, matching the hardware from Part 1:
+
+- **`nfs`** (the default) — backed by the Buffalo NAS over NFS, for bulk and
+  shared data.
+- **`local-path`** — fast, node-local storage on the 2 TB SSDs in the Proxmox
+  workers, for anything latency-sensitive.
+
+## What runs on top
+
+Everything is **GitOps**, managed by **ArgoCD** from a Git repo — Cilium,
+cert-manager, the storage drivers, and ArgoCD itself all reconcile from version
+control, so the cluster's desired state is the repo. On the workload side this is
+where the original goal from Part 1 finally lands: **Ollama** for local LLMs, and
+Plex with iGPU passthrough to one of the Proxmox workers.
+
+## What's next
+
+The cluster is up and self-managing. **Part 4** will go into the GitOps setup
+proper — how ArgoCD bootstraps everything, secrets handling, and exposing
+services with single sign-on.
+
+Seven nodes, two architectures, one `kubectl` away — and finally a place to run
+local AI that isn't someone else's cloud. It's all learning, and the stage just
+got bigger.


### PR DESCRIPTION
Adds **Part 3** (Talos Kubernetes cluster across the Proxmox VMs and the two Raspberry Pis) and updates **Part 1**'s Raspberry Pi section to reflect their real cluster roles (third control plane + arm64 worker), plus a corrected 3-CP / 4-worker summary.

Both posts are written high-level (detail trimmed) and run through the humanizer skill: no em/en dashes, AI-vocabulary and rule-of-three cleaned up, casual first-person voice. No internal IPs. Verified with a local Jekyll build.

Note: Part 1 is currently live, so this PR updates it.