### PR TITLE
Add official-docs links in Parts 1-3

### DIFF
--- a/_posts/2026-06-21-homelab-part-1-hardware.md
+++ b/_posts/2026-06-21-homelab-part-1-hardware.md
@@ -6,7 +6,7 @@ tags: [homelab, infrastructure, proxmox, kubernetes]
 ---
 
 First post in a series on building out my homelab. The goal is to run the same
-kind of infrastructure I work on (Kubernetes, GitOps, observability) without
+kind of infrastructure I work on ([Kubernetes](https://kubernetes.io/), GitOps, observability) without
 paying a cloud bill for every experiment. Part 1 is the hardware.
 
 ## How it started
@@ -15,7 +15,7 @@ I ran a homelab on a couple of Raspberry Pis for a while. They were great for
 poking at things: small, cheap, low power, and hard to break in any permanent
 way.
 
-Then I wanted to run models locally with Ollama, and the Pis ran out of room
+Then I wanted to run models locally with [Ollama](https://ollama.com/), and the Pis ran out of room
 fast. Fine for tinkering, not for anything memory hungry. I wanted a real
 multi-node setup I could run a proper Kubernetes cluster on, and host local LLMs
 without paying per token.
@@ -37,7 +37,7 @@ The two workhorses, plex1 and plex2. They're identical:
 | RAM | 24 GB |
 | Boot disk | ~256 GB NVMe |
 | Data disk | 2 TB SSD |
-| Hypervisor | Proxmox VE 9 |
+| Hypervisor | [Proxmox VE](https://www.proxmox.com/en/proxmox-virtual-environment/overview) 9 |
 
 A 35 W CPU sips power and stays quiet, but six cores and 24 GB are plenty for a
 few VMs, with enough headroom left for Ollama. I picked two boxes instead of one
@@ -47,7 +47,7 @@ learn how multi-node setups behave.
 ### 2x Raspberry Pi 5
 
 The Pis are still here, and they're not just tinkering boxes anymore. Both run
-Talos Linux as full members of the Kubernetes cluster (Part 3 covers that). One
+[Talos Linux](https://www.talos.dev/) as full members of the Kubernetes cluster (Part 3 covers that). One
 is a third control-plane node, the tie-breaker that gives etcd an odd-numbered
 quorum. The other is an arm64 worker. A Pi makes a good tie-breaker: low power,
 and unlike a laptop it comes back on by itself after an outage.

--- a/_posts/2026-06-22-homelab-part-2-proxmox.md
+++ b/_posts/2026-06-22-homelab-part-2-proxmox.md
@@ -6,7 +6,7 @@ tags: [homelab, proxmox, infrastructure]
 ---
 
 [Part 1]({{ '/2026/06/21/homelab-part-1-hardware.html' | relative_url }}) covered
-the hardware. This one is about Proxmox VE, the thing that turns those two mini
+the hardware. This one is about [Proxmox VE](https://www.proxmox.com/en/proxmox-virtual-environment/overview), the thing that turns those two mini
 PCs into boxes I can carve VMs out of. Both nodes run version 9.
 
 ## Installing it
@@ -34,8 +34,9 @@ on, so each node got a 2 TB SSD for the VM disks.
 | local-lvm | 256 GB NVMe | small system disks |
 | local-ssd | 2 TB SSD | the actual VM disks |
 
-I used LVM-thin rather than ZFS. These are single-disk nodes without much spare
-RAM, and ZFS wants more of both than this setup has to give.
+I used LVM-thin rather than [ZFS](https://openzfs.org/). These are single-disk
+nodes without much spare RAM, and ZFS wants more of both than this setup has to
+give.
 
 ## Networking
 

--- a/_posts/2026-06-22-homelab-part-3-kubernetes.md
+++ b/_posts/2026-06-22-homelab-part-3-kubernetes.md
@@ -7,8 +7,9 @@ tags: [homelab, kubernetes, talos, cilium, gitops]
 
 [Part 1]({{ '/2026/06/21/homelab-part-1-hardware.html' | relative_url }}) covered
 the hardware and [Part 2]({{ '/2026/06/22/homelab-part-2-proxmox.html' | relative_url }})
-got Proxmox running. This is where it comes together: a Kubernetes cluster spread
-across the Proxmox VMs and the Raspberry Pis, running Talos Linux.
+got Proxmox running. This is where it comes together: a
+[Kubernetes](https://kubernetes.io/) cluster spread across the Proxmox VMs and
+the Raspberry Pis, running [Talos Linux](https://www.talos.dev/).
 
 ## Why Talos
 
@@ -30,7 +31,7 @@ Seven nodes, mixed on purpose:
 | worker | worker4 | Raspberry Pi (arm64) |
 
 Three control planes, not two. Part 2 ended on the two-node quorum problem, and
-this is the fix: etcd wants an odd number, so a third control plane (a Pi) lets
+this is the fix: [etcd](https://etcd.io/) wants an odd number, so a third control plane (a Pi) lets
 the cluster survive losing any one of them. The control planes sit on different
 machines, and a floating virtual IP is the API endpoint, so kubectl talks to the
 cluster rather than to one node. The amd64 VMs and the arm64 Pis run side by
@@ -40,7 +41,7 @@ side, which keeps me honest about multi-arch images.
 
 A few things cost me real time.
 
-Cilium dropped traffic between nodes. With the default overlay, pods on the same
+[Cilium](https://cilium.io/) dropped traffic between nodes. With the default overlay, pods on the same
 node could talk but pods on different nodes couldn't, and it failed silently. On
 Proxmox the fix was switching Cilium to native routing.
 
@@ -59,8 +60,9 @@ local-path on the SSDs for anything that needs to be quick.
 
 ## What runs on it
 
-Everything is GitOps through ArgoCD, so the cluster's state is just a Git repo.
-On top of that sits the reason for the whole upgrade: Ollama for local LLMs, and
+Everything is GitOps through [ArgoCD](https://argo-cd.readthedocs.io/en/stable/),
+so the cluster's state is just a Git repo. On top of that sits the reason for the
+whole upgrade: [Ollama](https://ollama.com/) for local LLMs, and
 Plex with the iGPU passed through for transcoding.
 
 ## What's next

--- a/_posts/2026-06-23-homelab-part-4-argocd.md
+++ b/_posts/2026-06-23-homelab-part-4-argocd.md
@@ -1,0 +1,63 @@
+---
+layout: post
+title: "Homelab, Part 4: GitOps with ArgoCD"
+date: 2026-06-23
+tags: [homelab, kubernetes, argocd, gitops]
+---
+
+[Part 3]({{ '/2026/06/22/homelab-part-3-kubernetes.html' | relative_url }}) got
+the Talos cluster running. Part 4 is how I stop touching it by hand.
+[ArgoCD](https://argo-cd.readthedocs.io/en/stable/) watches a Git repo and
+reconciles the cluster to match it. I push, it deploys.
+
+## One repo, App-of-Apps
+
+The repo (`argo-home`) is the source of truth. Change something live and ArgoCD
+drifts it back; lose a node and the repo rebuilds it. I point ArgoCD at one
+[ApplicationSet](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/)
+that turns each folder into a managed app, so adding a service is a pull request,
+not a kubectl session.
+
+ArgoCD even manages itself. The only manual step is the first install; after that
+it adopts its own manifests and upgrades through Git. It needs
+[server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/),
+or the big CRD manifests blow past the annotation size limit.
+
+Today it keeps a deliberately short list in sync: ArgoCD,
+[Cilium](https://cilium.io/), [cert-manager](https://cert-manager.io/), and the
+two storage drivers. A few solid apps beat a dashboard full of
+half-broken ones.
+
+## Secrets with SOPS
+
+Secrets live in the repo too, encrypted with [SOPS](https://github.com/getsops/sops)
+and an [age](https://github.com/FiloSottile/age) key, so what gets committed is
+ciphertext. ArgoCD decrypts them at render time with
+[KSOPS](https://github.com/viaduct-ai/kustomize-sops), a generator plugin in the
+repo-server. The only thing not in Git is the age private
+key itself, loaded into the cluster once by hand. Each encrypted secret carries
+its own namespace, so one app fans them out to wherever they belong.
+
+Two things ate an afternoon:
+
+- The KSOPS image has no shell, so an init container running `/bin/sh -c` just
+  crash-loops. Call the binary directly.
+- ArgoCD's command-params config map doesn't restart its pod when it changes.
+  Restart it yourself, or run [Stakater Reloader](https://github.com/stakater/Reloader).
+
+One catch: ArgoCD caches rendered manifests, decrypted secrets included, in Redis
+as plaintext. The project discourages it for exactly that reason. Fine for a
+private one-person cluster, not for anywhere with real blast radius.
+
+## What else bit me
+
+I started with [MetalLB](https://metallb.universe.tf/) and pulled it out once Cilium handled load balancing. And
+on a fresh cluster, ApplicationSet order matters: namespaces have to exist before
+the apps that land in them.
+
+## Next
+
+The cluster runs itself, but I still reach it over the local network. Part 5 is
+exposing things properly: single sign-on with
+[Authentik](https://goauthentik.io/), and getting in from outside without opening
+the router.


### PR DESCRIPTION
Hyperlinks named tools/keywords to their official docs on first mention, matching what Part 4 (PR #14) does. Post dates are unchanged.

- Part 1: Kubernetes, Ollama, Talos Linux, Proxmox VE
- Part 2: Proxmox VE, ZFS
- Part 3: Kubernetes, Talos Linux, etcd, Cilium, ArgoCD, Ollama

All target URLs verified 200. No date changes, no em dashes, no internal IPs.