### PR TITLE
Add 'Continue reading' buttons to blog index

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -17,6 +17,9 @@ layout: compress
   .blog-main .post-tag:hover { text-decoration: underline; }
   .blog-main .back-to-blog { color: #97AAC3; text-decoration: none; font-size: 14px; }
   .blog-main .back-to-blog:hover { color: #2d7788; }
+  .blog-main .read-more { display: inline-block; margin-top: 4px; padding: 5px 12px; border: 1px solid #2d7788; border-radius: 4px; color: #2d7788; font-size: 13px; font-weight: 600; text-decoration: none; transition: background .15s ease, color .15s ease; }
+  .blog-main .read-more:hover { background: #2d7788; color: #fff; }
+  .blog-main .item .post-tags { margin-top: 12px; }
   @media (max-width: 600px) { .blog-main.main-wrapper { padding: 25px; } }
 </style>
 <body>

--- a/blog.html
+++ b/blog.html
@@ -20,6 +20,7 @@ permalink: /blog/
             </div><!--//meta-->
             <div class="details">
                 <p>{{ post.excerpt | strip_html | truncatewords: 40 }}</p>
+                <a class="read-more" href="{{ post.url | relative_url }}">Continue reading &rarr;</a>
                 {% if post.tags.size > 0 %}
                 <div class="post-tags">
                     {% for tag in post.tags %}


### PR DESCRIPTION
Adds a styled 'Continue reading ->' button under each post's excerpt on /blog, linking to the full post.