### PR TITLE
Make Continue reading subtle

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -17,9 +17,9 @@ layout: compress
   .blog-main .post-tag:hover { text-decoration: underline; }
   .blog-main .back-to-blog { color: #97AAC3; text-decoration: none; font-size: 14px; }
   .blog-main .back-to-blog:hover { color: #2d7788; }
-  .blog-main .read-more { display: inline-block; margin-top: 4px; padding: 5px 12px; border: 1px solid #2d7788; border-radius: 4px; color: #2d7788; font-size: 13px; font-weight: 600; text-decoration: none; transition: background .15s ease, color .15s ease; }
-  .blog-main .read-more:hover { background: #2d7788; color: #fff; }
-  .blog-main .item .post-tags { margin-top: 12px; }
+  .blog-main .read-more { color: #97AAC3; font-size: 12px; text-decoration: none; }
+  .blog-main .read-more:hover { color: #2d7788; text-decoration: underline; }
+  .blog-main .item .post-tags { margin-top: 8px; }
   @media (max-width: 600px) { .blog-main.main-wrapper { padding: 25px; } }
 </style>
 <body>


### PR DESCRIPTION
Restyle the per-post 'Continue reading' link from an outlined button to a small, muted text link so it takes less space.