### PR TITLE
Block AI crawlers (robots.txt + noai meta)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="{% if site.description %}{{ site.description }}{% else %}A beautiful Jekyll theme for creating resume{% endif %}">
+    <meta name="robots" content="index, follow, noai, noimageai">
     {% feed_meta %}
     <link rel="shortcut icon" href="favicon.ico">
     <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,400italic,300italic,300,500italic,700,700italic,900,900italic' rel='stylesheet' type='text/css'>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,38 @@
+# Allow normal search engines; block known AI training/scraping crawlers.
+
+User-agent: GPTBot
+Disallow: /
+User-agent: ChatGPT-User
+Disallow: /
+User-agent: OAI-SearchBot
+Disallow: /
+User-agent: ClaudeBot
+Disallow: /
+User-agent: anthropic-ai
+Disallow: /
+User-agent: Claude-Web
+Disallow: /
+User-agent: Google-Extended
+Disallow: /
+User-agent: CCBot
+Disallow: /
+User-agent: PerplexityBot
+Disallow: /
+User-agent: Applebot-Extended
+Disallow: /
+User-agent: Bytespider
+Disallow: /
+User-agent: Amazonbot
+Disallow: /
+User-agent: meta-externalagent
+Disallow: /
+User-agent: cohere-ai
+Disallow: /
+User-agent: Diffbot
+Disallow: /
+User-agent: ImagesiftBot
+Disallow: /
+
+# Everyone else welcome
+User-agent: *
+Disallow:


### PR DESCRIPTION
Adds robots.txt disallowing known AI training/scraping crawlers (GPTBot, ClaudeBot, Google-Extended, CCBot, PerplexityBot, Bytespider, etc.) while leaving normal search engines allowed, plus a noai/noimageai robots meta tag site-wide. Advisory-only (honored by compliant crawlers).